### PR TITLE
remove required checks for PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,7 +1,7 @@
 # https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
 
 github:
-  description: "Pekko gRPC Quickstart for Java"
+  description: "Apache Pekko gRPC Quickstart for Java"
   homepage: https://pekko.apache.org/
   labels:
     - pekko
@@ -27,13 +27,6 @@ github:
 
   protected_branches:
     main:
-      required_status_checks:
-        # strict means "Require branches to be up to date before merging".
-        strict: false
-        # contexts are the names of checks that must pass
-        contexts:
-          - Code is formatted
-          - Check headers
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false


### PR DESCRIPTION
We don't have checks that match these names - the config was copied from another Pekko repo but this it should not have been included.